### PR TITLE
Update protobufjs version.

### DIFF
--- a/lib/linter-proto.coffee
+++ b/lib/linter-proto.coffee
@@ -8,7 +8,7 @@ LinterProto =
   lint: (textEditor) ->
     return new Promise (resolve, reject) ->
       try
-        pbjs.loadProto(textEditor.getText(), null, textEditor.getPath())
+        pbjs.parse(textEditor.getText(), null, textEditor.getPath())
         resolve([])
       catch err
         lineNum = /\sat line (\d+):/.exec(err.message)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "protobufjs": "^4.0.0"
+    "protobufjs": "^6.0.0"
   },
   "providedServices": {
     "linter": {


### PR DESCRIPTION
This updates the protobufjs version to v6+ which supports protobuf 3 and well known types e.g. timestamp.

There's a problem with the line numbers being off, but it still works.